### PR TITLE
add missing apiVersion in opsdroid-service.yaml

### DIFF
--- a/opsdroid/templates/opsdroid-service.yaml
+++ b/opsdroid/templates/opsdroid-service.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: Service
 metadata:
   name: opsdroid


### PR DESCRIPTION
Summary :
The apiVersion was missing in opsdroid-service.yaml - leading to service not being created.

Error: release opsrdoid failed: namespace.x.x.x  "services" is forbidden: User "system:serviceaccount:namespace.x.x.x:namespace.x.x.x" cannot create resource "x:namespace.x.x.x" in API group "" at the cluster scope: No policy matched.

after change - the service comes up as below.

==> v1/Service
NAME      TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE
opsdroid  ClusterIP  172.21.246.198  <none>       8080/TCP  1s