### PR TITLE
Uncommented defaults for PVC

### DIFF
--- a/opsdroid/values.yaml
+++ b/opsdroid/values.yaml
@@ -17,12 +17,12 @@ opsdroid:
 
   pvc:
     enabled: false
-    # annotations: {}
-    # selector: {}
-    # accessModes:
-    #   - ReadWriteOnce
-    # storage: 5Gi
-    # storageClassName:
+    annotations: {}
+    selector: {}
+    accessModes:
+      - ReadWriteOnce
+    storage: 5Gi
+    storageClassName:
 
   ingress:
     enabled: false
@@ -64,9 +64,9 @@ rasanlu:
 
   pvc:
     enabled: false
-    # annotations: {}
-    # selector: {}
-    # accessModes:
-    #   - ReadWriteOnce
-    # storage: 5Gi
-    # storageClassName:
+    annotations: {}
+    selector: {}
+    accessModes:
+      - ReadWriteOnce
+    storage: 5Gi
+    storageClassName:


### PR DESCRIPTION
When just specifying `opsdroid.pvc.enabled=true` or `rasanlu.pvc.enabled=true`, you would have to specify some of the spec.
This PR makes the defaults available. They are still disregarded if PVC isn't enabled.