### PR TITLE
Update opsdroid image to v0.25.0

### DIFF
--- a/opsdroid/Chart.yaml
+++ b/opsdroid/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: opsdroid
 version: 0.1.4
-appVersion: 0.19.0
+appVersion: 0.25.0
 description: Opsdroid is a ChatOps bot framework written in Python
 keywords:
 - chatbot

--- a/opsdroid/values.yaml
+++ b/opsdroid/values.yaml
@@ -1,7 +1,7 @@
 opsdroid:
   image:
     repository: opsdroid/opsdroid
-    tag: v0.19.0
+    tag: v0.25.0
     imagePullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
This updates the image version to the latest available opsdroid image.
Short smoke test went fine (i.e. installed helm chart and talked to bot). 