### PR TITLE
fix(ingress): Use `$` to reference root values in range block

### DIFF
--- a/charts/opsdroid/templates/opsdroid-ingress.yaml
+++ b/charts/opsdroid/templates/opsdroid-ingress.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: opsdroid-{{ .Release.Name }}
+                name: opsdroid-{{ $.Release.Name }}
                 port:
                   number: {{ $.Values.opsdroid.service.port }}
     {{- end -}}


### PR DESCRIPTION
This fixes the following error when ingress is enabled:
```
Helm upgrade failed: template: opsdroid/templates/opsdroid-ingress.yaml:25:42: executing "opsdroid/templates/opsdroid-ingress.yaml" at <.Release.Name>: can't evaluate field Release in type interface {}
```

Within the `range` Block `.` references the current item. Therefor we need to use `$` to reference the root.