### PR TITLE
Add IngressClassName params

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ The following tables list the configurable parameters of the Opsdroid chart and 
 
 #### Ingress
 
-| Parameter                      | Description                        | Default |
-| ------------------------------ | ---------------------------------- | ------- |
-| `opsdroid.ingress.enabled`     | Use an Ingress to access opsdroid  | `false` |
-| `opsdroid.ingress.annotations` | Opsdroid Ingress annotations       | `{}`    |
-| `opsdroid.ingress.hosts`       | Opsdroid Ingress Hostnames         | `[]`    |
-| `opsdroid.ingress.tls`         | Opsdroid Ingress TLS configuration | `[]`    |
+| Parameter                           | Description                        | Default |
+| ----------------------------------- | ---------------------------------- | ------- |
+| `opsdroid.ingress.enabled`          | Use an Ingress to access opsdroid  | `false` |
+| `opsdroid.ingress.annotations`      | Opsdroid Ingress annotations       | `{}`    |
+| `opsdroid.ingress.hosts`            | Opsdroid Ingress Hostnames         | `[]`    |
+| `opsdroid.ingress.ingressClassName` | Opsdroid Ingress Class Name        | `nil`   |
+| `opsdroid.ingress.tls`              | Opsdroid Ingress TLS configuration | `[]`    |
 
 ### Rasa NLU
 

--- a/charts/opsdroid/templates/opsdroid-ingress.yaml
+++ b/charts/opsdroid/templates/opsdroid-ingress.yaml
@@ -13,6 +13,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  ingressClassName: {{ $.Values.ingress.ingressClassName }}
   rules:
     {{- range $host := .Values.opsdroid.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/opsdroid/templates/opsdroid-ingress.yaml
+++ b/charts/opsdroid/templates/opsdroid-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  ingressClassName: {{ $.Values.ingress.ingressClassName }}
+  ingressClassName: {{ $.Values.opsdroid.ingress.ingressClassName }}
   rules:
     {{- range $host := .Values.opsdroid.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/opsdroid/values.yaml
+++ b/charts/opsdroid/values.yaml
@@ -26,6 +26,7 @@ opsdroid:
 
   ingress:
     enabled: false
+    ingressClassName: ""
     # hosts:
     #   - opsdroid.example.com
     # annotations:


### PR DESCRIPTION
Fix ingress:  

annotation `kubernetes.io/ingress.class: nginx` isn't working anymore.